### PR TITLE
upgrade github package due to axios vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "axios-cache-interceptor": "^0.9.3",
     "did-jwt": "^5.7.0",
     "ethers": "^5.4.6",
-    "simple-github-gist-api": "^1.0.1"
+    "simple-github-gist-api": "^2.0.56"
   },
   "files": [
     "package.json",

--- a/tests/GithubGistContentHost.ts
+++ b/tests/GithubGistContentHost.ts
@@ -1,0 +1,35 @@
+import { InfuraProvider } from "@ethersproject/providers";
+import { Wallet } from "@ethersproject/wallet";
+
+import { GithubGistContentHost } from "../src/contentHost/github";
+import { Farcaster } from "../src/farcaster";
+import { Web3UserRegistry } from "../src/userRegistry";
+import { expectDefined } from "./utils";
+
+// Note: This is a live integration test. Running it requires a working github personal access token and
+// the private key of a registered Farcaster address.
+
+// See https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token#creating-a-token
+const githubPersonalAccessToken = "ghp_XXXXXXXXXXXXXXXXX";
+const privateKey = "..."; // 64 character hex string
+
+describe.skip("GithubGistContentHost", function () {
+  it("supports publishing a cast", async function () {
+    this.timeout(5000);
+    const githubContentHost = new GithubGistContentHost(
+      githubPersonalAccessToken
+    );
+    const farcaster = new Farcaster();
+    const provider = new InfuraProvider("rinkeby");
+    const signer = new Wallet(privateKey, provider);
+    const userRegistry = new Web3UserRegistry(provider);
+    const user = await userRegistry.lookupByAddress(signer.address);
+    expectDefined(user);
+    const unsignedCast = await farcaster.prepareCast({
+      fromUsername: user.username,
+      text: "This is a test cast written to a Github Gist",
+    });
+    const signedCast = await Farcaster.signCast(unsignedCast, signer);
+    await githubContentHost.publishCast(signedCast);
+  });
+});

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,0 +1,5 @@
+import { expect } from "chai";
+
+export function expectDefined<T>(arg: T): asserts arg is NonNullable<T> {
+  expect(arg).to.not.be.undefined;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,6 @@
       "./tests",
       "./examples"
     ],
-    "baseUrl": ".",
     "paths": {
       "@standard-crypto/farcaster-js": ["./src"],
       "@standard-crypto/farcaster-js/*": ["./src/*"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -2072,13 +2072,6 @@ axios-cache-interceptor@^0.9.3:
     fast-defer "^1.1.5"
     object-code "^1.2.0"
 
-axios@^0.19.2:
-  version "0.19.2"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
-  integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
-  dependencies:
-    follow-redirects "1.5.10"
-
 axios@^0.26.0:
   version "0.26.0"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.26.0.tgz#9a318f1c69ec108f8cd5f3c3d390366635e13928"
@@ -2830,13 +2823,6 @@ debug@4, debug@4.3.3, debug@^4.0.0, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, de
   integrity sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==
   dependencies:
     ms "2.1.2"
-
-debug@=3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
-  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
-  dependencies:
-    ms "2.0.0"
 
 debug@^2.6.9:
   version "2.6.9"
@@ -3675,13 +3661,6 @@ flatted@^3.1.0:
   version "3.2.5"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.5.tgz#76c8584f4fc843db64702a6bd04ab7a8bd666da3"
   integrity sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==
-
-follow-redirects@1.5.10:
-  version "1.5.10"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
-  integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
-  dependencies:
-    debug "=3.1.0"
 
 follow-redirects@^1.14.8:
   version "1.14.9"
@@ -6723,12 +6702,12 @@ signale@^1.2.1:
     figures "^2.0.0"
     pkg-conf "^2.1.0"
 
-simple-github-gist-api@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/simple-github-gist-api/-/simple-github-gist-api-1.0.1.tgz#ed8f1d3cc13e9cae62235c6b3f4ef39678baad20"
-  integrity sha512-Hl3YWr6qiJE1+xuszq0wFj9uzM9qvq4CYVTt+viZYyagQT8zTTjEQIXi6p6DGLqwKUOwwJrVCaWCCPSIuCfl5Q==
+simple-github-gist-api@^2.0.56:
+  version "2.0.56"
+  resolved "https://registry.yarnpkg.com/simple-github-gist-api/-/simple-github-gist-api-2.0.56.tgz#0c17726898ad8aed7cf3546cc94b5091203e843f"
+  integrity sha512-lYxMRCXrlyxEEkYKXhp6lbpzmrSOUNpi1kC/MWTZPfUvKXhk0y8WUwL87/PWZxqW9oHxxEUPPaBZdUH2QD47Tg==
   dependencies:
-    axios "^0.19.2"
+    axios "^0.26.0"
 
 slash@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Fixes #

* Bumps the gist library to `2.0.56`

## Description of the changes

* The v1 gist package has some `axios` vulnerability. The `v2` does not, so this PR makes the minimum amount of changes necessary to handle the breaking changes (afaik). 
* I did not add tests nor did I test out the changes I made to the gist/github workflow. Obviously this is not ideal. This PR is just being submitted as a starting point to the maintainer. Let me know if you'd like me to explore more testing
* There's probably a better way to handle the nullables - right now I'm just returning early which will definitely be confusing / problematic

Here is the audit report for current gist library issue:

```
npm audit
# npm audit report

axios  <=0.21.1
Severity: high
Incorrect Comparison in axios - https://github.com/advisories/GHSA-cph5-m8f7-6c5x
Server-Side Request Forgery in Axios - https://github.com/advisories/GHSA-4w2v-q235-vp99
Depends on vulnerable versions of follow-redirects
No fix available
node_modules/simple-github-gist-api/node_modules/axios
  simple-github-gist-api  <=1.0.1
  Depends on vulnerable versions of axios
  node_modules/simple-github-gist-api
    @standard-crypto/farcaster-js  *
    Depends on vulnerable versions of simple-github-gist-api
    node_modules/@standard-crypto/farcaster-js

follow-redirects  <=1.14.7
Severity: high
Exposure of Sensitive Information to an Unauthorized Actor in follow-redirects - https://github.com/advisories/GHSA-pw2r-vq6v-hr8c
Exposure of sensitive information in follow-redirects - https://github.com/advisories/GHSA-74fj-2j2h-c42q
No fix available
node_modules/simple-github-gist-api/node_modules/follow-redirects
  axios  <=0.21.1
  Depends on vulnerable versions of follow-redirects
  node_modules/simple-github-gist-api/node_modules/axios
    simple-github-gist-api  <=1.0.1
    Depends on vulnerable versions of axios
    node_modules/simple-github-gist-api
      @standard-crypto/farcaster-js  *
      Depends on vulnerable versions of simple-github-gist-api
      node_modules/@standard-crypto/farcaster-js

4 high severity vulnerabilities

Some issues need review, and may require choosing
a different dependency.
```
