### PR TITLE
Support arbitrary strings for cast targets

### DIFF
--- a/src/merkleAPI/MerkleAPIClient.ts
+++ b/src/merkleAPI/MerkleAPIClient.ts
@@ -823,7 +823,7 @@ export class MerkleAPIClient {
    */
   public async publishCast(
     text: string,
-    replyTo?: Cast | { fid: number; hash: string },
+    replyTo?: Cast | { fid: number; hash: string } | string,
     embeds?: string[]
   ): Promise<Cast> {
     const authToken = await this.getOrCreateValidAuthToken();
@@ -832,16 +832,21 @@ export class MerkleAPIClient {
       embeds,
     };
     if (replyTo !== undefined) {
-      let parentFid: number;
-      if ("author" in replyTo) {
-        parentFid = replyTo.author.fid;
-      } else {
-        parentFid = replyTo.fid;
+      if (typeof replyTo === "string") {
+        body.parent = replyTo;
+      } 
+      else {
+        let parentFid: number;
+        if ("author" in replyTo) {
+          parentFid = replyTo.author.fid;
+        } else {
+          parentFid = replyTo.fid;
+        }
+        body.parent = {
+          fid: parentFid,
+          hash: replyTo.hash,
+        };
       }
-      body.parent = {
-        fid: parentFid,
-        hash: replyTo.hash,
-      };
       if (embeds !== undefined) {
         body.embeds = embeds;
       }

--- a/src/merkleAPI/swagger/spec.json
+++ b/src/merkleAPI/swagger/spec.json
@@ -2106,6 +2106,7 @@
                               },
                               { "type": "string" }
                            ]
+                        }
                      },
                      "required":[
                         "text"

--- a/src/merkleAPI/swagger/spec.json
+++ b/src/merkleAPI/swagger/spec.json
@@ -2087,6 +2087,7 @@
                               "type":"string"
                            }
                         },
+                        // TODO: Should also accept { "type": "string" }
                         "parent":{
                            "type":"object",
                            "properties":{

--- a/src/merkleAPI/swagger/spec.json
+++ b/src/merkleAPI/swagger/spec.json
@@ -2087,22 +2087,25 @@
                               "type":"string"
                            }
                         },
-                        // TODO: Should also accept { "type": "string" }
-                        "parent":{
-                           "type":"object",
-                           "properties":{
-                              "fid":{
-                                 "$ref":"#/definitions/def-12"
+                        "parent": {
+                           "oneOf": [
+                              {
+                                 "type":"object",
+                                 "properties":{
+                                    "fid":{
+                                       "$ref":"#/definitions/def-12"
+                                    },
+                                    "hash":{
+                                       "$ref":"#/definitions/def-6"
+                                    }
+                                 },
+                                 "required":[
+                                    "fid",
+                                    "hash"
+                                 ]
                               },
-                              "hash":{
-                                 "$ref":"#/definitions/def-6"
-                              }
-                           },
-                           "required":[
-                              "fid",
-                              "hash"
+                              { "type": "string" }
                            ]
-                        }
                      },
                      "required":[
                         "text"


### PR DESCRIPTION
Fixes #

Hello, I would like to move #656 forward. I don't have have any experience with Swagger so I may be missing something.

## Description of the changes

- Updated `publishCast` to accept type `string` for `replyTo` 
- Updated `spec.json` to accept `{ "type": "string" }`