### PR TITLE
Add optional signer object to all Farcaster write methods

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -34,7 +34,8 @@
     "qrcode",
     "TYPEHASH",
     "Seedable", 
-    "Solana"
+    "Solana",
+    "neverthrow"
   ],
   "flagWords": [],
   "ignorePaths": [

--- a/README.md
+++ b/README.md
@@ -31,17 +31,41 @@ npm install axios @standard-crypto/farcaster-js-hub-rest
 <!-- AUTO-GENERATED-CONTENT:START (CODE:src=./examples/hubRest.ts) -->
 <!-- The below code snippet is automatically added from ./examples/hubRest.ts -->
 ```ts
-import { HubRestAPIClient } from '@standard-crypto/farcaster-js';
+import { HubRestAPIClient, ExternalEd25519Signer } from '@standard-crypto/farcaster-js';
+
+// Use an external signer
+import { NobleEd25519Signer } from '@farcaster/core';
 
 const client = new HubRestAPIClient();
 console.log(await client.getHubInfo());
 
+// Use a private key
 const signerPrivateKey = '0x...';
 const fid = 111;
 const writeClient = new HubRestAPIClient({ hubUrl: 'https://hub.farcaster.standardcrypto.vc:2281' });
 
 const publishCastResponse = await writeClient.submitCast({ text: 'This is a test cast submitted from farcaster-js' }, fid, signerPrivateKey);
 console.log(`new cast hash: ${publishCastResponse.hash}`);
+
+const nobleSigner = new NobleEd25519Signer(new Uint8Array([]));
+const _signMessage = async(messageHash: Uint8Array): Promise<Uint8Array> => {
+  const res = await nobleSigner.signMessageHash(messageHash);
+  if (res.isErr()) {
+    throw res.error;
+  }
+  return res._unsafeUnwrap();
+};
+const _getPublicKey = async(): Promise<Uint8Array> => {
+  const res = await nobleSigner.getSignerKey();
+  if (res.isErr()) {
+    throw res.error;
+  }
+  return res._unsafeUnwrap();
+};
+const externalSigner = new ExternalEd25519Signer(_signMessage, _getPublicKey);
+
+const publishCastExternalSignerResponse = await writeClient.submitCast({ text: 'This is a test cast submitted from farcaster-js using an external signer' }, fid, externalSigner);
+console.log(`new cast hash with external signer: ${publishCastExternalSignerResponse.hash}`);
 ```
 <!-- AUTO-GENERATED-CONTENT:END -->
 

--- a/examples/hubRest.ts
+++ b/examples/hubRest.ts
@@ -1,11 +1,27 @@
-import { HubRestAPIClient } from '@standard-crypto/farcaster-js';
+import { HubRestAPIClient, ExternalEd25519Signer } from '@standard-crypto/farcaster-js';
 
 const client = new HubRestAPIClient();
 console.log(await client.getHubInfo());
 
+// Use a private key
 const signerPrivateKey = '0x...';
 const fid = 111;
 const writeClient = new HubRestAPIClient({ hubUrl: 'https://hub.farcaster.standardcrypto.vc:2281' });
 
 const publishCastResponse = await writeClient.submitCast({ text: 'This is a test cast submitted from farcaster-js' }, fid, signerPrivateKey);
 console.log(`new cast hash: ${publishCastResponse.hash}`);
+
+// Use an external signer
+import { NobleEd25519Signer } from '@farcaster/core';
+
+const nobleSigner = new NobleEd25519Signer(new Uint8Array([...]));
+const _signMessage = async (messageHash: Uint8Array) => {
+    return nobleSigner.signMessageHash(messageHash);
+}
+const _getPublicKey = async () => {
+    return nobleSigner.getSignerKey();
+}
+const externalSigner = new ExternalEd25519Signer(_signMessage, _getPublicKey);
+
+const publishCastExternalSignerResponse = await writeClient.submitCast({ text: 'This is a test cast submitted from farcaster-js using an external signer' }, fid, externalSigner);
+console.log(`new cast hash with external signer: ${publishCastExternalSignerResponse.hash}`);

--- a/examples/hubRest.ts
+++ b/examples/hubRest.ts
@@ -15,11 +15,21 @@ const publishCastResponse = await writeClient.submitCast({ text: 'This is a test
 console.log(`new cast hash: ${publishCastResponse.hash}`);
 
 const nobleSigner = new NobleEd25519Signer(new Uint8Array([]));
-const externalSigner = new ExternalEd25519Signer(async(messageHash: Uint8Array) => {
-  return await nobleSigner.signMessageHash(messageHash);
-}, async() => {
-  return await nobleSigner.getSignerKey();
-});
+const _signMessage = async(messageHash: Uint8Array): Promise<Uint8Array> => {
+  const res = await nobleSigner.signMessageHash(messageHash);
+  if (res.isErr()) {
+    throw res.error;
+  }
+  return res._unsafeUnwrap();
+};
+const _getPublicKey = async(): Promise<Uint8Array> => {
+  const res = await nobleSigner.getSignerKey();
+  if (res.isErr()) {
+    throw res.error;
+  }
+  return res._unsafeUnwrap();
+};
+const externalSigner = new ExternalEd25519Signer(_signMessage, _getPublicKey);
 
 const publishCastExternalSignerResponse = await writeClient.submitCast({ text: 'This is a test cast submitted from farcaster-js using an external signer' }, fid, externalSigner);
 console.log(`new cast hash with external signer: ${publishCastExternalSignerResponse.hash}`);

--- a/examples/hubRest.ts
+++ b/examples/hubRest.ts
@@ -14,7 +14,7 @@ console.log(`new cast hash: ${publishCastResponse.hash}`);
 // Use an external signer
 import { NobleEd25519Signer } from '@farcaster/core';
 
-const nobleSigner = new NobleEd25519Signer(new Uint8Array([...]));
+const nobleSigner = new NobleEd25519Signer(new Uint8Array([]));
 const _signMessage = async (messageHash: Uint8Array) => {
     return nobleSigner.signMessageHash(messageHash);
 }

--- a/examples/hubRest.ts
+++ b/examples/hubRest.ts
@@ -1,5 +1,8 @@
 import { HubRestAPIClient, ExternalEd25519Signer } from '@standard-crypto/farcaster-js';
 
+// Use an external signer
+import { NobleEd25519Signer } from '@farcaster/core';
+
 const client = new HubRestAPIClient();
 console.log(await client.getHubInfo());
 
@@ -11,17 +14,12 @@ const writeClient = new HubRestAPIClient({ hubUrl: 'https://hub.farcaster.standa
 const publishCastResponse = await writeClient.submitCast({ text: 'This is a test cast submitted from farcaster-js' }, fid, signerPrivateKey);
 console.log(`new cast hash: ${publishCastResponse.hash}`);
 
-// Use an external signer
-import { NobleEd25519Signer } from '@farcaster/core';
-
 const nobleSigner = new NobleEd25519Signer(new Uint8Array([]));
-const _signMessage = async (messageHash: Uint8Array) => {
-    return nobleSigner.signMessageHash(messageHash);
-}
-const _getPublicKey = async () => {
-    return nobleSigner.getSignerKey();
-}
-const externalSigner = new ExternalEd25519Signer(_signMessage, _getPublicKey);
+const externalSigner = new ExternalEd25519Signer(async(messageHash: Uint8Array) => {
+  return await nobleSigner.signMessageHash(messageHash);
+}, async() => {
+  return await nobleSigner.getSignerKey();
+});
 
 const publishCastExternalSignerResponse = await writeClient.submitCast({ text: 'This is a test cast submitted from farcaster-js using an external signer' }, fid, externalSigner);
 console.log(`new cast hash with external signer: ${publishCastExternalSignerResponse.hash}`);

--- a/packages/farcaster-js-hub-rest/docs/classes/hubRestApiClient.HubRestAPIClient.md
+++ b/packages/farcaster-js-hub-rest/docs/classes/hubRestApiClient.HubRestAPIClient.md
@@ -73,7 +73,7 @@ Instantiates a HubRestAPIClient
 
 #### Defined in
 
-[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:119](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L119)
+[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:120](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L120)
 
 ## Properties
 
@@ -101,24 +101,24 @@ Instantiates a HubRestAPIClient
 
 #### Defined in
 
-[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:100](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L100)
+[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:101](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L101)
 
 ## Methods
 
 ### followUser
 
-▸ **followUser**(`targetFid`, `fid`, `signerPrivateKeyHex`): `Promise`\<[`LinkAdd`](../modules/openapi.md#linkadd)\>
+▸ **followUser**(`targetFid`, `fid`, `signer`): `Promise`\<[`LinkAdd`](../modules/openapi.md#linkadd)\>
 
 Follows a User. Wraps submitLink.
 See [farcaster documentation](https://www.thehubble.xyz/docs/httpapi/submitmessage.html#submitmessage)
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `targetFid` | `number` |
-| `fid` | `number` |
-| `signerPrivateKeyHex` | `string` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `targetFid` | `number` | The FID of the user to follow |
+| `fid` | `number` | The FID of the signer |
+| `signer` | `string` \| `Signer` | The signer's hex private key or Signer object |
 
 #### Returns
 
@@ -126,7 +126,7 @@ See [farcaster documentation](https://www.thehubble.xyz/docs/httpapi/submitmessa
 
 #### Defined in
 
-[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:297](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L297)
+[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:323](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L323)
 
 ___
 
@@ -149,7 +149,7 @@ See [farcaster documentation](https://www.thehubble.xyz/docs/httpapi/casts.html#
 
 #### Defined in
 
-[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:561](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L561)
+[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:607](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L607)
 
 ___
 
@@ -172,7 +172,7 @@ See [farcaster documentation](https://www.thehubble.xyz/docs/httpapi/events.html
 
 #### Defined in
 
-[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:1131](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L1131)
+[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:1179](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L1179)
 
 ___
 
@@ -202,7 +202,7 @@ See [farcaster documentation](https://www.thehubble.xyz/docs/httpapi/info.html#i
 
 #### Defined in
 
-[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:163](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L163)
+[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:177](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L177)
 
 ___
 
@@ -215,10 +215,10 @@ See [farcaster documentation](https://www.thehubble.xyz/docs/httpapi/links.html#
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `sourceFid` | `number` |
-| `targetFid` | `number` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `sourceFid` | `number` | The FID of the link's creator |
+| `targetFid` | `number` | The FID of the link's target |
 
 #### Returns
 
@@ -226,7 +226,7 @@ See [farcaster documentation](https://www.thehubble.xyz/docs/httpapi/links.html#
 
 #### Defined in
 
-[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:801](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L801)
+[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:849](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L849)
 
 ___
 
@@ -249,7 +249,7 @@ See [farcaster documentation](https://www.thehubble.xyz/docs/httpapi/onchain.htm
 
 #### Defined in
 
-[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:1105](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L1105)
+[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:1153](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L1153)
 
 ___
 
@@ -273,7 +273,7 @@ See [farcaster documentation](https://www.thehubble.xyz/docs/httpapi/onchain.htm
 
 #### Defined in
 
-[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:1078](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L1078)
+[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:1126](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L1126)
 
 ___
 
@@ -296,7 +296,7 @@ See [farcaster documentation](https://www.thehubble.xyz/docs/httpapi/reactions.h
 
 #### Defined in
 
-[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:675](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L675)
+[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:721](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L721)
 
 ___
 
@@ -320,7 +320,7 @@ See [farcaster documentation](https://www.thehubble.xyz/docs/httpapi/userdata.ht
 
 #### Defined in
 
-[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:894](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L894)
+[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:942](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L942)
 
 ___
 
@@ -343,7 +343,7 @@ See [farcaster documentation](https://www.thehubble.xyz/docs/httpapi/storagelimi
 
 #### Defined in
 
-[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:981](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L981)
+[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:1029](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L1029)
 
 ___
 
@@ -366,7 +366,7 @@ See [farcaster documentation](https://www.thehubble.xyz/docs/httpapi/usernamepro
 
 #### Defined in
 
-[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:992](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L992)
+[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:1040](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L1040)
 
 ___
 
@@ -390,7 +390,7 @@ See [farcaster documentation](https://www.thehubble.xyz/docs/httpapi/userdata.ht
 
 #### Defined in
 
-[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:921](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L921)
+[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:969](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L969)
 
 ___
 
@@ -414,7 +414,7 @@ See [farcaster documentation](https://www.thehubble.xyz/docs/httpapi/casts.html#
 
 #### Defined in
 
-[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:582](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L582)
+[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:628](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L628)
 
 ___
 
@@ -438,7 +438,7 @@ See [farcaster documentation](https://www.thehubble.xyz/docs/httpapi/casts.html#
 
 #### Defined in
 
-[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:613](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L613)
+[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:659](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L659)
 
 ___
 
@@ -462,7 +462,7 @@ See [farcaster documentation](https://www.thehubble.xyz/docs/httpapi/casts.html#
 
 #### Defined in
 
-[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:644](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L644)
+[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:690](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L690)
 
 ___
 
@@ -485,7 +485,7 @@ See [farcaster documentation](https://www.thehubble.xyz/docs/httpapi/fids.html#f
 
 #### Defined in
 
-[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:952](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L952)
+[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:1000](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L1000)
 
 ___
 
@@ -508,7 +508,7 @@ See [farcaster documentation](https://www.thehubble.xyz/docs/httpapi/events.html
 
 #### Defined in
 
-[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:1153](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L1153)
+[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:1201](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L1201)
 
 ___
 
@@ -532,7 +532,7 @@ See [farcaster documentation](https://www.thehubble.xyz/docs/httpapi/links.html#
 
 #### Defined in
 
-[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:829](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L829)
+[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:877](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L877)
 
 ___
 
@@ -556,7 +556,7 @@ See [farcaster documentation](https://www.thehubble.xyz/docs/httpapi/links.html#
 
 #### Defined in
 
-[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:861](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L861)
+[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:909](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L909)
 
 ___
 
@@ -586,7 +586,7 @@ See [farcaster documentation](https://www.thehubble.xyz/docs/httpapi/onchain.htm
 
 #### Defined in
 
-[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:1060](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L1060)
+[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:1108](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L1108)
 
 ___
 
@@ -612,7 +612,7 @@ See [farcaster documentation](https://www.thehubble.xyz/docs/httpapi/reactions.h
 
 #### Defined in
 
-[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:734](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L734)
+[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:780](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L780)
 
 ___
 
@@ -637,7 +637,7 @@ See [farcaster documentation](https://www.thehubble.xyz/docs/httpapi/reactions.h
 
 #### Defined in
 
-[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:699](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L699)
+[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:745](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L745)
 
 ___
 
@@ -662,7 +662,7 @@ See [farcaster documentation](https://www.thehubble.xyz/docs/httpapi/reactions.h
 
 #### Defined in
 
-[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:770](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L770)
+[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:816](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L816)
 
 ___
 
@@ -685,7 +685,7 @@ See [farcaster documentation](https://www.thehubble.xyz/docs/httpapi/usernamepro
 
 #### Defined in
 
-[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:1017](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L1017)
+[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:1065](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L1065)
 
 ___
 
@@ -709,24 +709,24 @@ See [farcaster documentation](https://www.thehubble.xyz/docs/httpapi/verificatio
 
 #### Defined in
 
-[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:1028](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L1028)
+[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:1076](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L1076)
 
 ___
 
 ### removeCast
 
-▸ **removeCast**(`castHash`, `fid`, `signerPrivateKeyHex`): `Promise`\<[`CastRemove`](../modules/openapi.md#castremove)\>
+▸ **removeCast**(`castHash`, `fid`, `signer`): `Promise`\<[`CastRemove`](../modules/openapi.md#castremove)\>
 
 Deletes a Cast.
 See [farcaster documentation](https://www.thehubble.xyz/docs/httpapi/submitmessage.html#submitmessage)
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `castHash` | `string` |
-| `fid` | `number` |
-| `signerPrivateKeyHex` | `string` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `castHash` | `string` | The hash of the cast to delete |
+| `fid` | `number` | The FID of the signer |
+| `signer` | `string` \| `Signer` | The signer's hex private key or Signer object |
 
 #### Returns
 
@@ -734,27 +734,27 @@ See [farcaster documentation](https://www.thehubble.xyz/docs/httpapi/submitmessa
 
 #### Defined in
 
-[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:230](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L230)
+[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:250](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L250)
 
 ___
 
 ### removeLink
 
-▸ **removeLink**(`link`, `fid`, `signerPrivateKeyHex`): `Promise`\<[`LinkRemove`](../modules/openapi.md#linkremove)\>
+▸ **removeLink**(`link`, `fid`, `signer`): `Promise`\<[`LinkRemove`](../modules/openapi.md#linkremove)\>
 
 Removes a Link. Used to unfollow users
 See [farcaster documentation](https://www.thehubble.xyz/docs/httpapi/submitmessage.html#submitmessage)
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `link` | `Object` |
-| `link.displayTimestamp?` | `number` |
-| `link.targetFid?` | `number` |
-| `link.type` | `string` |
-| `fid` | `number` |
-| `signerPrivateKeyHex` | `string` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `link` | `Object` | The link to remove |
+| `link.displayTimestamp?` | `number` | - |
+| `link.targetFid?` | `number` | - |
+| `link.type` | `string` | - |
+| `fid` | `number` | The FID of the signer |
+| `signer` | `string` \| `Signer` | The signer's hex private key or Signer object |
 
 #### Returns
 
@@ -762,26 +762,26 @@ See [farcaster documentation](https://www.thehubble.xyz/docs/httpapi/submitmessa
 
 #### Defined in
 
-[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:313](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L313)
+[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:342](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L342)
 
 ___
 
 ### removeReaction
 
-▸ **removeReaction**(`reaction`, `fid`, `signerPrivateKeyHex`): `Promise`\<[`ReactionRemove`](../modules/openapi.md#reactionremove)\>
+▸ **removeReaction**(`reaction`, `fid`, `signer`): `Promise`\<[`ReactionRemove`](../modules/openapi.md#reactionremove)\>
 
 Removes a Reaction. Used to un-like or un-recast.
 See [farcaster documentation](https://www.thehubble.xyz/docs/httpapi/submitmessage.html#submitmessage)
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `reaction` | `Object` |
-| `reaction.target` | [`CastId`](../interfaces/openapi.CastId.md) \| \{ `url`: `string`  } |
-| `reaction.type` | ``"like"`` \| ``"recast"`` |
-| `fid` | `number` |
-| `signerPrivateKeyHex` | `string` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `reaction` | `Object` | The reaction to remove |
+| `reaction.target` | [`CastId`](../interfaces/openapi.CastId.md) \| \{ `url`: `string`  } | - |
+| `reaction.type` | ``"like"`` \| ``"recast"`` | - |
+| `fid` | `number` | The FID of the signer |
+| `signer` | `string` \| `Signer` | The signer's hex private key or Signer object |
 
 #### Returns
 
@@ -789,24 +789,24 @@ See [farcaster documentation](https://www.thehubble.xyz/docs/httpapi/submitmessa
 
 #### Defined in
 
-[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:411](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L411)
+[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:449](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L449)
 
 ___
 
 ### removeVerification
 
-▸ **removeVerification**(`address`, `fid`, `signerPrivateKeyHex`): `Promise`\<[`VerificationRemove`](../modules/openapi.md#verificationremove)\>
+▸ **removeVerification**(`address`, `fid`, `signer`): `Promise`\<[`VerificationRemove`](../modules/openapi.md#verificationremove)\>
 
 Removes a Verification.
 See [farcaster documentation](https://www.thehubble.xyz/docs/httpapi/submitmessage.html#submitmessage)
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `address` | `string` |
-| `fid` | `number` |
-| `signerPrivateKeyHex` | `string` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `address` | `string` | The address to remove the verification for |
+| `fid` | `number` | The FID of the signer |
+| `signer` | `string` \| `Signer` | The signer's hex private key or Signer object |
 
 #### Returns
 
@@ -814,31 +814,31 @@ See [farcaster documentation](https://www.thehubble.xyz/docs/httpapi/submitmessa
 
 #### Defined in
 
-[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:529](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L529)
+[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:573](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L573)
 
 ___
 
 ### submitCast
 
-▸ **submitCast**(`cast`, `fid`, `signerPrivateKeyHex`): `Promise`\<[`CastAdd`](../modules/openapi.md#castadd)\>
+▸ **submitCast**(`cast`, `fid`, `signer`): `Promise`\<[`CastAdd`](../modules/openapi.md#castadd)\>
 
 Submits a Cast.
 See [farcaster documentation](https://www.thehubble.xyz/docs/httpapi/submitmessage.html#submitmessage)
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `cast` | `Object` |
-| `cast.embeds?` | `Embed`[] |
-| `cast.embedsDeprecated?` | `string`[] |
-| `cast.mentions?` | `number`[] |
-| `cast.mentionsPositions?` | `number`[] |
-| `cast.parentCastId?` | [`CastId`](../interfaces/openapi.CastId.md) |
-| `cast.parentUrl?` | `string` |
-| `cast.text` | `string` |
-| `fid` | `number` |
-| `signerPrivateKeyHex` | `string` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `cast` | `Object` | The cast to submit |
+| `cast.embeds?` | `Embed`[] | - |
+| `cast.embedsDeprecated?` | `string`[] | - |
+| `cast.mentions?` | `number`[] | - |
+| `cast.mentionsPositions?` | `number`[] | - |
+| `cast.parentCastId?` | [`CastId`](../interfaces/openapi.CastId.md) | - |
+| `cast.parentUrl?` | `string` | - |
+| `cast.text` | `string` | - |
+| `fid` | `number` | The FID of the signer |
+| `signer` | `string` \| `Signer` | The signer's hex private key or Signer object |
 
 #### Returns
 
@@ -846,27 +846,27 @@ See [farcaster documentation](https://www.thehubble.xyz/docs/httpapi/submitmessa
 
 #### Defined in
 
-[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:174](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L174)
+[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:191](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L191)
 
 ___
 
 ### submitLink
 
-▸ **submitLink**(`link`, `fid`, `signerPrivateKeyHex`): `Promise`\<[`LinkAdd`](../modules/openapi.md#linkadd)\>
+▸ **submitLink**(`link`, `fid`, `signer`): `Promise`\<[`LinkAdd`](../modules/openapi.md#linkadd)\>
 
 Submits a Link. Used to follow users.
 See [farcaster documentation](https://www.thehubble.xyz/docs/httpapi/submitmessage.html#submitmessage)
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `link` | `Object` |
-| `link.displayTimestamp?` | `number` |
-| `link.targetFid?` | `number` |
-| `link.type` | `string` |
-| `fid` | `number` |
-| `signerPrivateKeyHex` | `string` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `link` | `Object` | The link to submit |
+| `link.displayTimestamp?` | `number` | - |
+| `link.targetFid?` | `number` | - |
+| `link.type` | `string` | - |
+| `fid` | `number` | The FID of the signer |
+| `signer` | `string` \| `Signer` | The signer's hex private key or Signer object |
 
 #### Returns
 
@@ -874,26 +874,26 @@ See [farcaster documentation](https://www.thehubble.xyz/docs/httpapi/submitmessa
 
 #### Defined in
 
-[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:265](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L265)
+[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:288](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L288)
 
 ___
 
 ### submitReaction
 
-▸ **submitReaction**(`reaction`, `fid`, `signerPrivateKeyHex`): `Promise`\<[`Reaction`](../modules/openapi.md#reaction)\>
+▸ **submitReaction**(`reaction`, `fid`, `signer`): `Promise`\<[`Reaction`](../modules/openapi.md#reaction)\>
 
 Submits a Reaction. Used to like or recast.
 See [farcaster documentation](https://www.thehubble.xyz/docs/httpapi/submitmessage.html#submitmessage)
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `reaction` | `Object` |
-| `reaction.target` | [`CastId`](../interfaces/openapi.CastId.md) \| \{ `url`: `string`  } |
-| `reaction.type` | ``"like"`` \| ``"recast"`` |
-| `fid` | `number` |
-| `signerPrivateKeyHex` | `string` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `reaction` | `Object` | The reaction to submit |
+| `reaction.target` | [`CastId`](../interfaces/openapi.CastId.md) \| \{ `url`: `string`  } | - |
+| `reaction.type` | ``"like"`` \| ``"recast"`` | - |
+| `fid` | `number` | The FID of the signer |
+| `signer` | `string` \| `Signer` | The signer's hex private key or Signer object |
 
 #### Returns
 
@@ -901,28 +901,28 @@ See [farcaster documentation](https://www.thehubble.xyz/docs/httpapi/submitmessa
 
 #### Defined in
 
-[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:361](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L361)
+[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:396](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L396)
 
 ___
 
 ### submitVerification
 
-▸ **submitVerification**(`verification`, `fid`, `signerPrivateKeyHex`): `Promise`\<[`Verification`](../modules/openapi.md#verification)\>
+▸ **submitVerification**(`verification`, `fid`, `signer`): `Promise`\<[`Verification`](../modules/openapi.md#verification)\>
 
 Submits a Verification.
 See [farcaster documentation](https://www.thehubble.xyz/docs/httpapi/submitmessage.html#submitmessage)
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `verification` | `Object` |
-| `verification.chainId` | `number` |
-| `verification.network` | ``"MAINNET"`` \| ``"TESTNET"`` \| ``"DEVNET"`` |
-| `verification.verificationType` | ``"EOA"`` \| ``"contract"`` |
-| `verification.verifiedAddressMnemonicOrPrivateKey` | `string` |
-| `fid` | `number` |
-| `signerPrivateKeyHex` | `string` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `verification` | `Object` | The verification to submit |
+| `verification.chainId` | `number` | - |
+| `verification.network` | ``"MAINNET"`` \| ``"TESTNET"`` \| ``"DEVNET"`` | - |
+| `verification.verificationType` | ``"EOA"`` \| ``"contract"`` | - |
+| `verification.verifiedAddressMnemonicOrPrivateKey` | `string` | - |
+| `fid` | `number` | The FID of the signer |
+| `signer` | `string` \| `Signer` | The signer's hex private key or Signer object |
 
 #### Returns
 
@@ -930,24 +930,24 @@ See [farcaster documentation](https://www.thehubble.xyz/docs/httpapi/submitmessa
 
 #### Defined in
 
-[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:461](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L461)
+[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:502](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L502)
 
 ___
 
 ### unfollowUser
 
-▸ **unfollowUser**(`targetFid`, `fid`, `signerPrivateKeyHex`): `Promise`\<[`LinkRemove`](../modules/openapi.md#linkremove)\>
+▸ **unfollowUser**(`targetFid`, `fid`, `signer`): `Promise`\<[`LinkRemove`](../modules/openapi.md#linkremove)\>
 
 Un-follows a User. Wraps removeLink.
 See [farcaster documentation](https://www.thehubble.xyz/docs/httpapi/submitmessage.html#submitmessage)
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `targetFid` | `number` |
-| `fid` | `number` |
-| `signerPrivateKeyHex` | `string` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `targetFid` | `number` | The FID of the user to unfollow |
+| `fid` | `number` | The FID of the signer |
+| `signer` | `string` \| `Signer` | The signer's hex private key or Signer object |
 
 #### Returns
 
@@ -955,7 +955,7 @@ See [farcaster documentation](https://www.thehubble.xyz/docs/httpapi/submitmessa
 
 #### Defined in
 
-[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:345](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L345)
+[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:377](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L377)
 
 ___
 
@@ -980,7 +980,7 @@ See [farcaster documentation](https://github.com/farcasterxyz/hub-monorepo/blob/
 
 #### Defined in
 
-[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:1180](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L1180)
+[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:1228](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L1228)
 
 ___
 
@@ -1004,4 +1004,4 @@ error is Object
 
 #### Defined in
 
-[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:1197](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L1197)
+[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:1245](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L1245)

--- a/packages/farcaster-js-hub-rest/docs/interfaces/hubRestApiClient.HubRestAPIClientConfig.md
+++ b/packages/farcaster-js-hub-rest/docs/interfaces/hubRestApiClient.HubRestAPIClientConfig.md
@@ -20,7 +20,7 @@
 
 #### Defined in
 
-[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:87](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L87)
+[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:88](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L88)
 
 ___
 
@@ -30,7 +30,7 @@ ___
 
 #### Defined in
 
-[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:88](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L88)
+[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:89](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L89)
 
 ___
 
@@ -40,4 +40,4 @@ ___
 
 #### Defined in
 
-[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:89](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L89)
+[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:90](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L90)

--- a/packages/farcaster-js-hub-rest/docs/interfaces/hubRestApiClient.PaginationOptions.md
+++ b/packages/farcaster-js-hub-rest/docs/interfaces/hubRestApiClient.PaginationOptions.md
@@ -19,7 +19,7 @@
 
 #### Defined in
 
-[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:93](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L93)
+[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:94](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L94)
 
 ___
 
@@ -29,4 +29,4 @@ ___
 
 #### Defined in
 
-[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:94](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L94)
+[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:95](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L95)

--- a/packages/farcaster-js-hub-rest/docs/modules/hubRestApiClient.md
+++ b/packages/farcaster-js-hub-rest/docs/modules/hubRestApiClient.md
@@ -36,7 +36,7 @@
 
 #### Defined in
 
-[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:80](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L80)
+[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:81](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L81)
 
 ___
 
@@ -52,7 +52,7 @@ ___
 
 #### Defined in
 
-[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:70](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L70)
+[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:71](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L71)
 
 ## Variables
 
@@ -62,4 +62,4 @@ ___
 
 #### Defined in
 
-[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:84](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L84)
+[packages/farcaster-js-hub-rest/src/hubRestApiClient.ts:85](https://github.com/standard-crypto/farcaster-js/blob/main/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts#L85)

--- a/packages/farcaster-js-hub-rest/package.json
+++ b/packages/farcaster-js-hub-rest/package.json
@@ -13,6 +13,7 @@
   "license": "MIT",
   "dependencies": {
     "@farcaster/core": "^0.14.8",
+    "neverthrow": "^6.0.0",
     "viem": "^1.12.2"
   },
   "peerDependencies": {

--- a/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts
+++ b/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts
@@ -60,6 +60,7 @@ import {
   makeVerificationRemove,
   CastAddBody,
   Protocol,
+  Signer,
 } from '@farcaster/core';
 import {
   eip712SignerFromMnemonicOrPrivateKey,
@@ -157,6 +158,19 @@ export class HubRestAPIClient {
   }
 
   /**
+   * Takes in a hex private key or Signer object and returns a Signer object.
+   * If the input is a hex private key, it will be converted to a Signer object.
+   * 
+   * @param signer The signer's hex private key or Signer object
+   */
+  private formatSigner(signer: string | Signer): Signer {
+    if (typeof signer === 'string') {
+      return hexToSigner(signer);
+    }
+    return signer;
+  }
+
+  /**
    * Get the Hub's info.
    * See [farcaster documentation](https://www.thehubble.xyz/docs/httpapi/info.html#info)
    */
@@ -170,6 +184,9 @@ export class HubRestAPIClient {
   /**
    * Submits a Cast.
    * See [farcaster documentation](https://www.thehubble.xyz/docs/httpapi/submitmessage.html#submitmessage)
+   * @param cast The cast to submit
+   * @param fid The FID of the signer
+   * @param signer The signer's hex private key or Signer object
    */
   public async submitCast(
     cast: {
@@ -182,7 +199,7 @@ export class HubRestAPIClient {
       parentUrl?: string
     },
     fid: number,
-    signerPrivateKeyHex: string,
+    signer: string | Signer,
   ): Promise<CastAdd> {
     const dataOptions = {
       fid: fid,
@@ -211,7 +228,7 @@ export class HubRestAPIClient {
     const msg = await makeCastAdd(
       castAdd,
       dataOptions,
-      hexToSigner(signerPrivateKeyHex),
+      this.formatSigner(signer),
     );
     if (msg.isErr()) {
       throw msg.error;
@@ -226,11 +243,14 @@ export class HubRestAPIClient {
   /**
    * Deletes a Cast.
    * See [farcaster documentation](https://www.thehubble.xyz/docs/httpapi/submitmessage.html#submitmessage)
+   * @param castHash The hash of the cast to delete
+   * @param fid The FID of the signer
+   * @param signer The signer's hex private key or Signer object
    */
   public async removeCast(
     castHash: string,
     fid: number,
-    signerPrivateKeyHex: string,
+    signer: string | Signer,
   ): Promise<CastRemove> {
     const dataOptions = {
       fid: fid,
@@ -245,7 +265,7 @@ export class HubRestAPIClient {
     const msg = await makeCastRemove(
       castToRemove,
       dataOptions,
-      hexToSigner(signerPrivateKeyHex),
+      this.formatSigner(signer),
     );
     if (msg.isErr()) {
       throw msg.error;
@@ -261,6 +281,9 @@ export class HubRestAPIClient {
   /**
    * Submits a Link. Used to follow users.
    * See [farcaster documentation](https://www.thehubble.xyz/docs/httpapi/submitmessage.html#submitmessage)
+   * @param link The link to submit
+   * @param fid The FID of the signer
+   * @param signer The signer's hex private key or Signer object
    */
   public async submitLink(
     link: {
@@ -269,7 +292,7 @@ export class HubRestAPIClient {
       targetFid?: number
     },
     fid: number,
-    signerPrivateKeyHex: string,
+    signer: string | Signer,
   ): Promise<LinkAdd> {
     const dataOptions = {
       fid: fid,
@@ -278,7 +301,7 @@ export class HubRestAPIClient {
     const msg = await makeLinkAdd(
       link,
       dataOptions,
-      hexToSigner(signerPrivateKeyHex),
+      this.formatSigner(signer),
     );
     if (msg.isErr()) {
       throw msg.error;
@@ -293,22 +316,28 @@ export class HubRestAPIClient {
   /**
    * Follows a User. Wraps submitLink.
    * See [farcaster documentation](https://www.thehubble.xyz/docs/httpapi/submitmessage.html#submitmessage)
+   * @param targetFid The FID of the user to follow
+   * @param fid The FID of the signer
+   * @param signer The signer's hex private key or Signer object
    */
   public async followUser(
     targetFid: number,
     fid: number,
-    signerPrivateKeyHex: string,
+    signer: string | Signer,
   ): Promise<LinkAdd> {
     return await this.submitLink(
       { type: 'follow', targetFid: targetFid },
       fid,
-      signerPrivateKeyHex,
+      this.formatSigner(signer),
     );
   }
 
   /**
    * Removes a Link. Used to unfollow users
    * See [farcaster documentation](https://www.thehubble.xyz/docs/httpapi/submitmessage.html#submitmessage)
+   * @param link The link to remove
+   * @param fid The FID of the signer
+   * @param signer The signer's hex private key or Signer object
    */
   public async removeLink(
     link: {
@@ -317,7 +346,7 @@ export class HubRestAPIClient {
       targetFid?: number
     },
     fid: number,
-    signerPrivateKeyHex: string,
+    signer: string | Signer,
   ): Promise<LinkRemove> {
     const dataOptions = {
       fid: fid,
@@ -326,7 +355,7 @@ export class HubRestAPIClient {
     const msg = await makeLinkRemove(
       link,
       dataOptions,
-      hexToSigner(signerPrivateKeyHex),
+      this.formatSigner(signer),
     );
     if (msg.isErr()) {
       throw msg.error;
@@ -341,22 +370,28 @@ export class HubRestAPIClient {
   /**
    * Un-follows a User. Wraps removeLink.
    * See [farcaster documentation](https://www.thehubble.xyz/docs/httpapi/submitmessage.html#submitmessage)
+   * @param targetFid The FID of the user to unfollow
+   * @param fid The FID of the signer
+   * @param signer The signer's hex private key or Signer object
    */
   public async unfollowUser(
     targetFid: number,
     fid: number,
-    signerPrivateKeyHex: string,
+    signer: string | Signer,
   ): Promise<LinkRemove> {
     return await this.removeLink(
       { type: 'follow', targetFid: targetFid },
       fid,
-      signerPrivateKeyHex,
+      this.formatSigner(signer),
     );
   }
 
   /**
    * Submits a Reaction. Used to like or recast.
    * See [farcaster documentation](https://www.thehubble.xyz/docs/httpapi/submitmessage.html#submitmessage)
+   * @param reaction The reaction to submit
+   * @param fid The FID of the signer
+   * @param signer The signer's hex private key or Signer object
    */
   public async submitReaction(
     reaction: {
@@ -364,7 +399,7 @@ export class HubRestAPIClient {
       target: CastId | { url: string }
     },
     fid: number,
-    signerPrivateKeyHex: string,
+    signer: string | Signer,
   ): Promise<Reaction> {
     const dataOptions = {
       fid: fid,
@@ -392,7 +427,7 @@ export class HubRestAPIClient {
     const msg = await makeReactionAdd(
       reactionAdd,
       dataOptions,
-      hexToSigner(signerPrivateKeyHex),
+      this.formatSigner(signer),
     );
     if (msg.isErr()) {
       throw msg.error;
@@ -407,6 +442,9 @@ export class HubRestAPIClient {
   /**
    * Removes a Reaction. Used to un-like or un-recast.
    * See [farcaster documentation](https://www.thehubble.xyz/docs/httpapi/submitmessage.html#submitmessage)
+   * @param reaction The reaction to remove
+   * @param fid The FID of the signer
+   * @param signer The signer's hex private key or Signer object
    */
   public async removeReaction(
     reaction: {
@@ -414,7 +452,7 @@ export class HubRestAPIClient {
       target: CastId | { url: string }
     },
     fid: number,
-    signerPrivateKeyHex: string,
+    signer: string | Signer,
   ): Promise<ReactionRemove> {
     const dataOptions = {
       fid: fid,
@@ -442,7 +480,7 @@ export class HubRestAPIClient {
     const msg = await makeReactionRemove(
       reactionRemove,
       dataOptions,
-      hexToSigner(signerPrivateKeyHex),
+      this.formatSigner(signer),
     );
     if (msg.isErr()) {
       throw msg.error;
@@ -457,6 +495,9 @@ export class HubRestAPIClient {
   /**
    * Submits a Verification.
    * See [farcaster documentation](https://www.thehubble.xyz/docs/httpapi/submitmessage.html#submitmessage)
+   * @param verification The verification to submit
+   * @param fid The FID of the signer
+   * @param signer The signer's hex private key or Signer object
    */
   public async submitVerification(
     verification: {
@@ -466,7 +507,7 @@ export class HubRestAPIClient {
       chainId: number
     },
     fid: number,
-    signerPrivateKeyHex: string,
+    signer: string | Signer,
   ): Promise<Verification> {
     const dataOptions = {
       fid: fid,
@@ -510,7 +551,7 @@ export class HubRestAPIClient {
     const msg = await makeVerificationAddEthAddress(
       verificationAdd,
       dataOptions,
-      hexToSigner(signerPrivateKeyHex),
+      this.formatSigner(signer),
     );
     if (msg.isErr()) {
       throw msg.error;
@@ -525,11 +566,14 @@ export class HubRestAPIClient {
   /**
    * Removes a Verification.
    * See [farcaster documentation](https://www.thehubble.xyz/docs/httpapi/submitmessage.html#submitmessage)
+   * @param address The address to remove the verification for
+   * @param fid The FID of the signer
+   * @param signer The signer's hex private key or Signer object
    */
   public async removeVerification(
     address: string,
     fid: number,
-    signerPrivateKeyHex: string,
+    signer: string | Signer,
   ): Promise<VerificationRemove> {
     const dataOptions = {
       fid: fid,
@@ -542,7 +586,7 @@ export class HubRestAPIClient {
     const msg = await makeVerificationRemove(
       { address: addressBytes.value, protocol: Protocol.ETHEREUM },
       dataOptions,
-      hexToSigner(signerPrivateKeyHex),
+      this.formatSigner(signer),
     );
     if (msg.isErr()) {
       throw msg.error;
@@ -557,6 +601,8 @@ export class HubRestAPIClient {
   /**
    * Get a cast by its FID and Hash.
    * See [farcaster documentation](https://www.thehubble.xyz/docs/httpapi/casts.html#castbyid)
+   * @param fid The FID of the cast's creator
+   * @param hash The hash of the cast
    */
   public async getCastById({ fid, hash }: CastId): Promise<CastAdd | null> {
     try {
@@ -797,6 +843,8 @@ export class HubRestAPIClient {
   /**
    * Get a link by its FID and target FID.
    * See [farcaster documentation](https://www.thehubble.xyz/docs/httpapi/links.html#linkbyid)
+   * @param sourceFid The FID of the link's creator
+   * @param targetFid The FID of the link's target
    */
   public async getLinkById(
     sourceFid: number,

--- a/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts
+++ b/packages/farcaster-js-hub-rest/src/hubRestApiClient.ts
@@ -160,7 +160,7 @@ export class HubRestAPIClient {
   /**
    * Takes in a hex private key or Signer object and returns a Signer object.
    * If the input is a hex private key, it will be converted to a Signer object.
-   * 
+   *
    * @param signer The signer's hex private key or Signer object
    */
   private formatSigner(signer: string | Signer): Signer {

--- a/packages/farcaster-js-hub-rest/src/index.ts
+++ b/packages/farcaster-js-hub-rest/src/index.ts
@@ -2,3 +2,4 @@ export * from './hubRestApiClient.js';
 export * as FarcasterEpochTimestamp from './farcasterEpochTimestamp.js';
 export * from './logger.js';
 export * from './openapi/index.js';
+export * from './signers.js';

--- a/packages/farcaster-js-hub-rest/src/signers.ts
+++ b/packages/farcaster-js-hub-rest/src/signers.ts
@@ -31,7 +31,7 @@ export class ExternalEd25519Signer extends Ed25519Signer {
         try {
             return ok(await this._getSignerKey());
         } catch (e) {
-            return err(new HubError("unknown", (e as any).message));
+            return err(new HubError("unknown", e instanceof Error ? e.message : "Unable to get signer key"));
         }
     }
     
@@ -46,7 +46,7 @@ export class ExternalEd25519Signer extends Ed25519Signer {
             const signature = await this._signMessageHash(hash);
             return ok(signature);
         } catch (e) {
-            return err(new HubError("unknown", (e as any).message));
+            return err(new HubError("unknown", e instanceof Error ? e.message : "Unable to get signer key"));
         }
     }
     

--- a/packages/farcaster-js-hub-rest/src/signers.ts
+++ b/packages/farcaster-js-hub-rest/src/signers.ts
@@ -1,53 +1,51 @@
-import { Ed25519Signer, HubAsyncResult, HubError } from "@farcaster/core";
-import { err, ok } from "neverthrow";
+import { Ed25519Signer, HubAsyncResult, HubError } from '@farcaster/core';
+import { err, ok } from 'neverthrow';
 
 /**
  * External Ed25519 signer that allows signatures to be computed by an external service.
  */
 export class ExternalEd25519Signer extends Ed25519Signer {
+  private readonly _signMessageHash: (messageHash: Uint8Array) => Promise<Uint8Array>;
+  private readonly _getSignerKey: () => Promise<Uint8Array>;
 
-    private _signMessageHash: (messageHash: Uint8Array) => Promise<Uint8Array>;
-    private _getSignerKey: () => Promise<Uint8Array>;
-  
-    /**
+  /**
      * Creates a new ExternalEd25519Signer. This class allows the signing of Farcaster message hashes to be delegated to an external service
      * such that a private key is not required to be in memory.
-     * 
+     *
      * @param signMessageHash Proxy function that signs a message hash. Called internally by _signMessageHash.
      * @param getSignerKey Proxy function that returns the public key of the signer. Called internally by _getSignerKey.
      */
-    constructor(signMessageHash: (messageHash: Uint8Array) => Promise<Uint8Array>, getSignerKey: () => Promise<Uint8Array>) {
-      super();
-      this._signMessageHash = signMessageHash;
-      this._getSignerKey = getSignerKey;
-    }
-  
-    /**
+  constructor(signMessageHash: (messageHash: Uint8Array) => Promise<Uint8Array>, getSignerKey: () => Promise<Uint8Array>) {
+    super();
+    this._signMessageHash = signMessageHash;
+    this._getSignerKey = getSignerKey;
+  }
+
+  /**
      * Returns the public key of the signer as a Uint8Array.
-     * 
+     *
      * @returns public key of the signer
      */
-    public async getSignerKey(): HubAsyncResult<Uint8Array> {
-        try {
-            return ok(await this._getSignerKey());
-        } catch (e) {
-            return err(new HubError("unknown", e instanceof Error ? e.message : "Unable to get signer key"));
-        }
+  public async getSignerKey(): HubAsyncResult<Uint8Array> {
+    try {
+      return ok(await this._getSignerKey());
+    } catch (e) {
+      return err(new HubError('unknown', e instanceof Error ? e.message : 'Unable to get signer key'));
     }
-    
-    /**
+  }
+
+  /**
      * Signs a Farcaster message hash.
-     * 
+     *
      * @param hash blake3 hash of the Farcaster message to be signed
      * @returns signature of the hash
      */
-    public async signMessageHash(hash: Uint8Array): HubAsyncResult<Uint8Array> {
-        try {
-            const signature = await this._signMessageHash(hash);
-            return ok(signature);
-        } catch (e) {
-            return err(new HubError("unknown", e instanceof Error ? e.message : "Unable to sign message hash"));
-        }
+  public async signMessageHash(hash: Uint8Array): HubAsyncResult<Uint8Array> {
+    try {
+      const signature = await this._signMessageHash(hash);
+      return ok(signature);
+    } catch (e) {
+      return err(new HubError('unknown', e instanceof Error ? e.message : 'Unable to sign message hash'));
     }
-    
+  }
 }

--- a/packages/farcaster-js-hub-rest/src/signers.ts
+++ b/packages/farcaster-js-hub-rest/src/signers.ts
@@ -13,8 +13,8 @@ export class ExternalEd25519Signer extends Ed25519Signer {
      * Creates a new ExternalEd25519Signer. This class allows the signing of Farcaster message hashes to be delegated to an external service
      * such that a private key is not required to be in memory.
      * 
-     * @param signMessageHash Proxy function that signs a message hash. Called internally by signMessageHash.
-     * @param getSignerKey Proxy function that returns the public key of the signer. Called internally by getSignerKey.
+     * @param signMessageHash Proxy function that signs a message hash. Called internally by _signMessageHash.
+     * @param getSignerKey Proxy function that returns the public key of the signer. Called internally by _getSignerKey.
      */
     constructor(signMessageHash: (messageHash: Uint8Array) => Promise<Uint8Array>, getSignerKey: () => Promise<Uint8Array>) {
       super();
@@ -46,7 +46,7 @@ export class ExternalEd25519Signer extends Ed25519Signer {
             const signature = await this._signMessageHash(hash);
             return ok(signature);
         } catch (e) {
-            return err(new HubError("unknown", e instanceof Error ? e.message : "Unable to get signer key"));
+            return err(new HubError("unknown", e instanceof Error ? e.message : "Unable to sign message hash"));
         }
     }
     

--- a/packages/farcaster-js-hub-rest/src/signers.ts
+++ b/packages/farcaster-js-hub-rest/src/signers.ts
@@ -1,0 +1,53 @@
+import { Ed25519Signer, HubAsyncResult, HubError } from "@farcaster/core";
+import { err, ok } from "neverthrow";
+
+/**
+ * External Ed25519 signer that allows signatures to be computed by an external service.
+ */
+export class ExternalEd25519Signer extends Ed25519Signer {
+
+    private _signMessageHash: (messageHash: Uint8Array) => Promise<Uint8Array>;
+    private _getSignerKey: () => Promise<Uint8Array>;
+  
+    /**
+     * Creates a new ExternalEd25519Signer. This class allows the signing of Farcaster message hashes to be delegated to an external service
+     * such that a private key is not required to be in memory.
+     * 
+     * @param signMessageHash Proxy function that signs a message hash. Called internally by signMessageHash.
+     * @param getSignerKey Proxy function that returns the public key of the signer. Called internally by getSignerKey.
+     */
+    constructor(signMessageHash: (messageHash: Uint8Array) => Promise<Uint8Array>, getSignerKey: () => Promise<Uint8Array>) {
+      super();
+      this._signMessageHash = signMessageHash;
+      this._getSignerKey = getSignerKey;
+    }
+  
+    /**
+     * Returns the public key of the signer as a Uint8Array.
+     * 
+     * @returns public key of the signer
+     */
+    public async getSignerKey(): HubAsyncResult<Uint8Array> {
+        try {
+            return ok(await this._getSignerKey());
+        } catch (e) {
+            return err(new HubError("unknown", (e as any).message));
+        }
+    }
+    
+    /**
+     * Signs a Farcaster message hash.
+     * 
+     * @param hash blake3 hash of the Farcaster message to be signed
+     * @returns signature of the hash
+     */
+    public async signMessageHash(hash: Uint8Array): HubAsyncResult<Uint8Array> {
+        try {
+            const signature = await this._signMessageHash(hash);
+            return ok(signature);
+        } catch (e) {
+            return err(new HubError("unknown", (e as any).message));
+        }
+    }
+    
+}

--- a/packages/farcaster-js-hub-rest/src/signers.ts
+++ b/packages/farcaster-js-hub-rest/src/signers.ts
@@ -1,5 +1,5 @@
 import { Ed25519Signer, HubAsyncResult, HubError } from '@farcaster/core';
-import { err, ok } from 'neverthrow'; // cspell:disable-line
+import { err, ok } from 'neverthrow';
 
 /**
  * External Ed25519 signer that allows signatures to be computed by an external service.

--- a/packages/farcaster-js-hub-rest/src/signers.ts
+++ b/packages/farcaster-js-hub-rest/src/signers.ts
@@ -1,5 +1,5 @@
 import { Ed25519Signer, HubAsyncResult, HubError } from '@farcaster/core';
-import { err, ok } from 'neverthrow';
+import { err, ok } from 'neverthrow'; // cspell:disable-line
 
 /**
  * External Ed25519 signer that allows signatures to be computed by an external service.

--- a/packages/farcaster-js-hub-rest/tests/integration/hubRestAPIClient.ts
+++ b/packages/farcaster-js-hub-rest/tests/integration/hubRestAPIClient.ts
@@ -53,7 +53,7 @@ describe('HubWebClient', function() {
   let client: HubRestAPIClient;
   let apiSpec: OverrideProperties<OpenAPIV3.Document, { paths: SchemaPaths }>; // cspell:disable-line
 
-  let signers: (string | Signer)[] = [];
+  const signers: Array<string | Signer> = [];
 
   before('setup', async function() {
     client = new HubRestAPIClient({
@@ -75,13 +75,13 @@ describe('HubWebClient', function() {
       // Build wrapped ED25519 signer in an ExternalEd25519Signer
       const privateKeyBytes = hexToBytes(signerPrivateKey.slice(2));
       const ed25519Signer = new NobleEd25519Signer(privateKeyBytes);
-      const externalSigner = new ExternalEd25519Signer(async (messageHash: Uint8Array) => {
+      const externalSigner = new ExternalEd25519Signer(async(messageHash: Uint8Array) => {
         const res = await ed25519Signer.signMessageHash(messageHash);
         if (res.isErr()) {
           throw res.error;
         }
         return res._unsafeUnwrap();
-      }, async () => {
+      }, async() => {
         const res = await ed25519Signer.getSignerKey();
         if (res.isErr()) {
           throw res.error;

--- a/packages/farcaster-js/src/index.ts
+++ b/packages/farcaster-js/src/index.ts
@@ -1,4 +1,4 @@
-export { HubRestAPIClient, FarcasterEpochTimestamp } from '@standard-crypto/farcaster-js-hub-rest';
+export { HubRestAPIClient, FarcasterEpochTimestamp, ExternalEd25519Signer } from '@standard-crypto/farcaster-js-hub-rest';
 export { NeynarAPIClient, waitForNeynarSignerApproval } from '@standard-crypto/farcaster-js-neynar';
 export * as NeynarV1 from '@standard-crypto/farcaster-js-neynar/v1';
 export * as NeynarV2 from '@standard-crypto/farcaster-js-neynar/v2';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2219,6 +2219,7 @@ __metadata:
     ethers: "npm:^6.8.1"
     markdown-magic: "npm:^2.6.1"
     mocha: "npm:^10.2.0"
+    neverthrow: "npm:^6.0.0"
     openapi-response-validator: "npm:^12.1.3"
     openapi-types: "npm:^12.1.3"
     openapi-typescript: "npm:^6.7.0"


### PR DESCRIPTION
# Summary

Adds an optional `Signer` object (from @farcaster/core) to all write methods where a private key hex string would be taken.

Parameterizes the SubmitApi tests to iterate over a list of signers (includes a raw private key string and an ExternalEd25519Signer instance).

## Description

- Renames `signerPrivateKeyHex` parameter to `signer` for all farcaster write methods
- Updates `signerPrivateKeyHex` (now `signer`) type from `string` to `string | Signer`
- Creates helper function that accepts a `string | Signer` input and returns the Signer back or converts the string to a `Signer`
- Adds tests for the new `ExternalEd25519Signer` class

The above changes will allow developers to create signer abstractions that do not permit to private keys to be available in memory.
